### PR TITLE
Fix to "Call to undefined method" with Laravel 6

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -67,6 +67,7 @@ class Plugin extends PluginBase
         try {
             $monolog = Log::getLogger();
         } catch (\Error $e) {
+            // Fallback to Log::getMonolog() for October based on Laravel 5.5 and below.
             if (starts_with($e->getMessage(), "Call to undefined method Illuminate\Log\Writer::getLogger()")) {
                 $monolog = Log::getMonolog();
             } else {

--- a/Plugin.php
+++ b/Plugin.php
@@ -64,7 +64,7 @@ class Plugin extends PluginBase
      */
     public function boot()
     {
-        $monolog = Log::getMonolog();
+        $monolog = Log::getLogger();
 
         $this->setNativeMailerHandler($monolog);
         $this->setSlackHandler($monolog);

--- a/Plugin.php
+++ b/Plugin.php
@@ -64,7 +64,15 @@ class Plugin extends PluginBase
      */
     public function boot()
     {
-        $monolog = Log::getLogger();
+        try {
+            $monolog = Log::getLogger();
+        } catch (\Error $e) {
+            if (starts_with($e->getMessage(), "Call to undefined method Illuminate\Log\Writer::getLogger()")) {
+                $monolog = Log::getMonolog();
+            } else {
+                throw $e;
+            }
+        }
 
         $this->setNativeMailerHandler($monolog);
         $this->setSlackHandler($monolog);

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.0",
         "composer/installers": "~1.0"
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
This PR fixes the issue #10. This is working with my project based on the latest October version with Laravel 6.

**Cause:**
`Log::getMonolog()` was removed since Laravel 5.6.

**Fix:**
Replace `Log::getMonolog()` with `Log::getLogger()`.

Since `Log::getLogger()` does not work with Laravel 5.5, I added fallback with `Log::getMonolog()` using try-catch.

Also, in order to use try-catch, I have to change the required php version to at least 7.0. I thought it was ok, because October requires 7.0 since 4 years ago already.