### PR TITLE
Fix to "Call to undefined method" with Laravel 6

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -64,7 +64,8 @@ class Plugin extends PluginBase
      */
     public function boot()
     {
-        $monolog = Log::getMonolog();
+        $isLaravel56OrUp = method_exists(\Illuminate\Log\Logger::class, 'getLogger');
+        $monolog = $isLaravel56OrUp ? Log::getLogger() : Log::getMonolog();
 
         $this->setNativeMailerHandler($monolog);
         $this->setSlackHandler($monolog);


### PR DESCRIPTION
This PR fixes the issue #10. This fix is working with my projects based on the latest October version with Laravel 6 and previous version with Laravel 5.5.

I dropped PR #11 and adopted the approach in #12 , which unfortunately the PR itself does not fix the problem properly.
So this is the fixed version of #12 .

**Cause:**
`Log::getMonolog()` was removed since Laravel 5.6.

**Fix:**
`Replace Log::getMonolog()` with `Log::getLogger()`.

To check method availability, this checks against `\Illuminate\Log\Logger::getLogger` instead of `\Illuminate\Log\Write::getLogger`, because `\Illuminate\Log\Write` is replaced with `\Illuminate\Log\Logger` since Laravel 5.6.